### PR TITLE
Change Z3 version to 4.8.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,11 @@ RUN apt-get update -qqy && DEBIAN_FRONTEND=noninteractive apt-get install -qqy -
     unzip \
 && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
-ARG VERSION=4.8.5
-ARG FILE=z3-$VERSION-x64-debian-8.11
+ARG VERSION=4.8.8
+ARG FILE=z3-$VERSION-x64-ubuntu-16.04
 
 RUN cd /tmp \
-    && curl -LOSs https://github.com/Z3Prover/z3/releases/download/Z3-$VERSION/$FILE.zip \
+    && curl -LOSs https://github.com/Z3Prover/z3/releases/download/z3-$VERSION/$FILE.zip \
     && unzip -qq -o $FILE.zip \
     && cp $FILE/bin/z3 /usr/local/bin/z3 \
     && cp $FILE/bin/libz3.so /usr/local/lib/libz3.so \


### PR DESCRIPTION
# Description

Update Z3 version to 4.8.8.
Have to use the Ubuntu archive as Debian archives are no longer provided in Z3 releases.

# Testing

The manual test test.sh works and an assignment was successfully graded in a local instance of A+.

# Have you updated the README or other relevant documentation?

Not relevant, naming scheme not changed.

# Is it [Done](https://wiki.aalto.fi/display/EDIT/Definition+of+Done)?

- [ ] I (developer) have created unit tests and the tests pass
- [ ] I (developer) have created functional tests (Selenium tests) if applicable
- [x] I (developer) have tested the changes manually
- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
